### PR TITLE
Multiple changes to get ringing-lib to compiled with visual studio 2015:

### DIFF
--- a/apps/methsearch/mask.cpp
+++ b/apps/methsearch/mask.cpp
@@ -61,6 +61,7 @@
 #include <ringing/streamutils.h>
 #include <ringing/mathutils.h>
 #include <ringing/place_notation.h>
+#include <iterator>
 
 #if RINGING_DEBUG_FILE
 #define DEBUG( expr ) (void)((cout << expr) << endl)

--- a/apps/methsearch/methodutils.cpp
+++ b/apps/methsearch/methodutils.cpp
@@ -44,6 +44,7 @@
 #include <ringing/method.h>
 #include <ringing/streamutils.h>
 #include <ringing/mathutils.h>
+#include <iterator>
 
 
 RINGING_USING_NAMESPACE

--- a/apps/methsearch/prog_args.cpp
+++ b/apps/methsearch/prog_args.cpp
@@ -785,7 +785,7 @@ bool arguments::validate( arg_parser &ap )
     ap.error( "--loop is only supported with --random" );
     return false;
   }
-  if ( random_order > 0 && ( filter_mode || filter_lib_mode ) ) {
+  if ( random_order && ( filter_mode || filter_lib_mode ) ) {
     ap.error( "--random cannot be used when filtering" );
     return false;
   }
@@ -876,7 +876,7 @@ bool arguments::validate( arg_parser &ap )
       return false;
     }
 
-  if ( hunt_bells & floating_sym )
+  if ( hunt_bells && floating_sym )
     {
       ap.error( "--floating-sym is not supported with hunt bells" );
       return false;

--- a/apps/utils/exec.cpp
+++ b/apps/utils/exec.cpp
@@ -67,9 +67,9 @@
 RINGING_USING_NAMESPACE
 RINGING_USING_STD
 
-class system_error : public logic_error {
+class System_error : public logic_error {
 public:
-  system_error( int errnum, const char* fn );
+  System_error( int errnum, const char* fn );
 };
 
 #if RINGING_WINDOWS && !defined(__CYGWIN__)
@@ -104,14 +104,14 @@ string windows_errstr( int errnum )
   return s;
 }
 
-system_error::system_error( int errnum, const char* fn )
+System_error::System_error( int errnum, const char* fn )
   : logic_error( make_string() << "System error: " << fn << ": " 
 		   << windows_errstr( errnum ) )
 {
 }
 
 #define THROW_SYSTEM_ERROR( str ) \
-  do { throw system_error( GetLastError(), str ); } while (false)
+  do { throw System_error( GetLastError(), str ); } while (false)
 
 
 /*
@@ -427,14 +427,14 @@ string exec_command( const string& str, int* cmd_status )
 
 #else // !RINGING_WINDOWS -- assume POSIX
 
-system_error::system_error( int errnum, const char* fn )
+System_error::System_error( int errnum, const char* fn )
   : logic_error( make_string() << "System error: " << fn << ": " 
 		   << strerror(errnum) )
 {
 }
 
 #define THROW_SYSTEM_ERROR( str ) \
-  do { throw system_error( errno, str ); } while (false)
+  do { throw System_error( errno, str ); } while (false)
 
 
 string exec_command( const string& str, int* cmd_status )

--- a/ringing/cclib.cpp
+++ b/ringing/cclib.cpp
@@ -232,7 +232,7 @@ bool cclib::impl::entry_type::readentry( library_base &lb )
 	  parse_title();
 	}
     }
-  return ifs;
+  return bool(ifs);
 }
 
 void cclib::impl::entry_type::parse_title()

--- a/ringing/group.cpp
+++ b/ringing/group.cpp
@@ -38,6 +38,7 @@
 #include <vector>
 #include <algorithm>
 #include <limits>
+#include <iterator>
 #endif
 
 RINGING_START_NAMESPACE

--- a/ringing/litelib.cpp
+++ b/ringing/litelib.cpp
@@ -62,7 +62,7 @@ public:
 private:
   void skip_bom();
 
-  virtual bool good(void) const { return f; }
+  virtual bool good(void) const { return bool(f); }
 
 private:
   int b;
@@ -196,7 +196,7 @@ bool litelib::impl::entry_type::readentry( library_base &lb )
       }
     }
 
-  return ifs;
+  return bool(ifs);
 }
 
 library_base::const_iterator litelib::impl::begin() const

--- a/ringing/method.cpp
+++ b/ringing/method.cpp
@@ -43,6 +43,7 @@
 #include <ringing/method.h>
 #include <ringing/place_notation.h>
 #include <ringing/row.h>
+#include <iterator>
 
 #ifdef _MSC_VER
 // Microsoft have unilaterally deprecated snprintf in favour of a non-standard
@@ -287,7 +288,7 @@ int method::methclass(void) const
 
   // Find the first hunt bell
   row lhr = lh();
-  for(hb = 0; lhr[hb] != hb && hb < bells(); ++hb);
+  for(hb = 0; hb < bells() && lhr[hb] != hb; ++hb);
   
   // Find the size of the first set of working bells    
   int wb=0;

--- a/ringing/mslib.cpp
+++ b/ringing/mslib.cpp
@@ -164,7 +164,7 @@ bool mslib::impl::entry_type::readentry( library_base &lb )
 	}
     }
 
-  return ifs;
+  return bool(ifs);
 }
 
 string mslib::impl::entry_type::name() const

--- a/ringing/music.cpp
+++ b/ringing/music.cpp
@@ -273,7 +273,7 @@ void music_node::add(const music_details &md, unsigned int i, unsigned int key, 
 		{
 		  // There are more to go
 		  // Any of them '*'s?
-		  if (mds.find('*', i + 1) >= mds.size())
+		  if (mds.find('*', i + 1) == string::npos)
 		    {
 		      // Deal with the only * to go in the add_to_subtree
 		      // function.
@@ -302,11 +302,12 @@ void music_node::add_to_subtree(unsigned int place, const music_details &md, uns
   cloning_pointer<music_node>& j = subnodes[place];
   if (!j) j.reset( new music_node(bells) );
 
-  string const& mds = md.get();  if (process_star)
+  string const& mds = md.get();
+  if (process_star)
     {
       // We are to process star data star.
       if (bells - pos == count_bells(mds.substr(i, mds.size() - i)) + 1 &&
-	  mds.find('*', i + 1) >= mds.size())
+	  mds.find('*', i + 1) == string::npos)
 	// There are now only numbers to go.
 	j->add(md, i + 1, key, pos + 1);
       else
@@ -332,16 +333,21 @@ bool music_node::match(const row &r, unsigned int pos,
     matched = true;
   }
 
+
+
   // Try all against ? or *
   BellNodeMap::const_iterator j = subnodes.find(0);
   if (j != subnodes.end())
     matched = j->second->match(r, pos + 1, results, stroke) || matched;
-    
-  // Now try the actual number
-  j = subnodes.find(r[pos] + 1);
-  if (j != subnodes.end())
-    matched = j->second->match(r, pos + 1, results, stroke) || matched;
 
+  // Now try the actual number
+  if (pos < r.bells())
+  {
+	  j = subnodes.find(r[pos] + 1);
+	  if (j != subnodes.end())
+		  matched = j->second->match(r, pos + 1, results, stroke) || matched;
+
+  }
   return matched;
 }
 

--- a/ringing/proof.h
+++ b/ringing/proof.h
@@ -174,22 +174,25 @@ public:
 
   // Constructor - 1 extent only.
   proof(RowIterator first, RowIterator last, bool qp = false) 
-    : istrue(prove(first, last, qp)) 
-  {}
+  {
+	  istrue = prove(first, last, qp);
+  }
 
   // Constructor - multiple extents.
   proof(RowIterator first, RowIterator last, const int max, 
 	bool qp = false)
-    : istrue(prove(first, last, max, qp)) 
-  {}
+  {
+	  istrue = prove(first, last, max, qp);
+  }
 
   proof(RowIterator true_first,
 	RowIterator true_last,
 	RowIterator unknown_first,
 	RowIterator unknown_last,
 	bool qp = false)
-    : istrue(prove(true_first, true_last, unknown_first, unknown_last, qp))
-  {}
+  {
+	  istrue = prove(true_first, true_last, unknown_first, unknown_last, qp);
+  }
 
   proof(RowIterator true_first,
 	RowIterator true_last,
@@ -197,8 +200,9 @@ public:
 	RowIterator unknown_last,
 	const int max,
 	bool qp = false)
-    : istrue(prove(true_first, true_last, unknown_first, unknown_last, max, qp))
-  {}
+  {
+	  istrue = prove(true_first, true_last, unknown_first, unknown_last, max, qp);
+  }
 
   bool prove(RowIterator first, RowIterator last, 
 	     bool qp = false) {

--- a/ringing/row_wildcard.cpp
+++ b/ringing/row_wildcard.cpp
@@ -136,6 +136,7 @@ bool row_wildcard::copy_if_choices_contains( string& dest,
   if ( p_sym > p_end ) return false;
   dest += sym;
   pos = p_end;
+  return true;
 }
 
 bool row_wildcard::copy_choices_intersection( string& dest, 
@@ -190,7 +191,7 @@ bool row_wildcard::make_intersection( string& dest,
     else if ( b_wild && a_bell )
       dest += a[ai];
 
-    else if ( a_bell && a_bell ) {
+    else if ( a_bell && b_bell ) {
       if ( a[ai] == b[bi] ) 
         dest += a[ai];
       else return false;

--- a/ringing/table_search.cpp
+++ b/ringing/table_search.cpp
@@ -94,13 +94,13 @@ table_search::table_search( const method &meth, const vector<change> &calls,
 {}
 
 table_search::table_search( const method &meth, const vector<change> &calls,
-                            pair< size_t, size_t > lenrange, bool set_nr )
-  : meth( meth ), calls( calls ),
-    lenrange( range_div( lenrange, f & length_in_changes
-                                     ? partends.size() * meth.length() : 1) ),
-    f( set_nr ? ignore_rotations : no_flags )
+                            pair< size_t, size_t > _lenrange, bool set_nr )
+  : meth( meth ), calls( calls ), f( set_nr ? ignore_rotations : no_flags )
 {
-  DEBUG( "Length range set to " << lenrange.first << "-" << lenrange.second 
+	lenrange = range_div(_lenrange, f & length_in_changes
+		? partends.size() * meth.length() : 1);
+
+DEBUG( "Length range set to " << lenrange.first << "-" << lenrange.second 
          << " leads" );
 }
 

--- a/tests/change-test.cpp
+++ b/tests/change-test.cpp
@@ -21,6 +21,7 @@
 #include <ringing/row.h>
 #include <ringing/streamutils.h>
 #include "test-base.h"
+#include <iterator>
 
 RINGING_START_NAMESPACE
 

--- a/tests/row-test.cpp
+++ b/tests/row-test.cpp
@@ -21,6 +21,7 @@
 #include <ringing/streamutils.h>
 #include <ringing/mathutils.h>
 #include "test-base.h"
+#include <iterator>
 
 RINGING_START_NAMESPACE
 


### PR DESCRIPTION
FIXED buffer overrun bug - put guard before access rather than after: ringing/method.cpp

FIXED buffer overrun bug on row access - pos >= bells: ringing/music.cpp

FIXED cases where constructor initialisation used data before it was initialised. These were particularly challenging to identify.
According to the standard initialisation should occur in the same order as definition. I believe VS does this correctly which results in problems as follows:
proof - istrue invokes prove which may use where before it is initialised
table_search - lenrange uses f which could be uninitialised

FIXED case where function might not return a value: ringing/row_wildcard.cpp

FIXED what I believe is an error in make_intersection where a_bell && a_bell occurs: ringing/row_wildcard.cpp

Added missing iterator include: apps/methsearch/{mask.cpp, methodutils.cpp), ringing/{group.cpp, method.cpp}, test/{change-test.cpp, row-test.cpp}
Fixed bool > int and int & bool warnings: apps/methsearch/prog_args.cpp
Fixed name clash with std::system_error: apps/utils/exec.cpp
Forced conversion of stream to bool on return: ringing/{cclib.cpp, litelib.cpp, mslib.cpp}

Changed find to use check against string::npos: ringing/music.cpp
Minor cosmetic change: ringing/music.cpp
