### PR TITLE
Fix failing unit tests and configure CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run:
+          sudo apt-get install
+            autoconf
+            automake
+            build-essential
+            dejagnu
+            help2man
+            libgdome2-dev
+            libreadline-dev
+            libtool
+
+      - name: autoreconf
+        run: autoreconf -i
+
+      - name: configure
+        run: ./configure
+
+      - name: make
+        run: make
+
+      - name: make check
+        run: make check
+
+      - name: Store test results
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-suite.log
+          path: tests/test-suite.log
+          if-no-files-found: error

--- a/tests/method-test.cpp
+++ b/tests/method-test.cpp
@@ -76,11 +76,11 @@ void test_method_fullname(void)
 
   RINGING_TEST( method( "-", 8, 
 			"Cross" ).fullname()
-		== "Cross Differential Major" );
+		== "Cross Major" );
 
   RINGING_TEST( method( "-4-6-6-4-6-6-2", 6, 
 			"Tetley's Smoothflow" ).fullname()
-		== "Tetley's Smoothflow Differential Hybrid Minor" );
+		== "Tetley's Smoothflow Differential Minor" );
 }
 
 void test_method_fullname_grandsire(void)
@@ -156,8 +156,11 @@ void test_method_classname(void)
 		== string("Treble Place") );
   RINGING_TEST( method::classname( method::M_ALLIANCE     ) 
 		== string("Alliance") );
+  // Since the adoption of the Framework for Method Ringing, v1.00
+  // on 1 July 2019, the Hybrid class has not formed part of the method 
+  // name.
   RINGING_TEST( method::classname( method::M_HYBRID       )
-		== string("Hybrid") );
+		== string("") );
   RINGING_TEST( method::classname( method::M_SLOW_COURSE  )
 		== string("Slow Course") );
   RINGING_TEST( method::classname( method::M_DIFFERENTIAL )
@@ -168,7 +171,7 @@ void test_method_classname(void)
 		== string("Little Bob") );
   RINGING_TEST( method::classname( method::M_HYBRID       | 
 				   method::M_LITTLE       )
-		== string("Little Hybrid") );
+		== string("Little") );
   RINGING_TEST( method::classname( method::M_SURPRISE     | 
 				   method::M_DIFFERENTIAL )
 		== string("Differential Surprise") );


### PR DESCRIPTION
## Why?

The following tests are currently failing on `master`.

```
method-test.cpp:77: Test failed: method( "-", 8, "Cross" ).fullname() == "Cross Differential Major"
method-test.cpp:81: Test failed: method( "-4-6-6-4-6-6-2", 6, "Tetley's Smoothflow" ).fullname() == "Tetley's Smoothflow Differential Hybrid Minor"
method-test.cpp:159: Test failed: method::classname( method::M_HYBRID ) == string("Hybrid")
method-test.cpp:169: Test failed: method::classname( method::M_HYBRID | method::M_LITTLE ) == string("Little Hybrid")
```

We've updated method code to reflect the adoption of the [_Framework for Method Ringing_](https://framework.cccbr.org.uk/), but hadn't updated tests to match.

We should run tests on every push in order to spot this more quickly in future.

## What?

* update expected results for broken tests
* create simple GitHub Actions workflow to build and test the library