### PR TITLE
Makefile: exit on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SUBDIRS := ringing utils apps #tests
 
 all docs install clean::
 	for dir in $(SUBDIRS); do \
-	  $(MAKE) -C $$dir $@; \
+	  $(MAKE) -C $$dir $@ || exit; \
 	done
 
 .PHONY: all docs install clean $(SUBDIRS)

--- a/apps/Makefile
+++ b/apps/Makefile
@@ -4,7 +4,7 @@ SUBDIRS := gsiril psline methsearch fextent extent touchsearch \
 
 all docs install clean::
 	for dir in $(SUBDIRS); do \
-	  $(MAKE) -C $$dir $@; \
+	  $(MAKE) -C $$dir $@ || exit; \
 	done
 
 .PHONY: all docs install clean $(SUBDIRS)


### PR DESCRIPTION
Update the Makefile to exit on error. The existing Makefile continued through all the build directories, and returned 0 even if one of the directories failed to build.