### PR TITLE
Fix gcc15 compilation

### DIFF
--- a/ringing/methodset.cpp
+++ b/ringing/methodset.cpp
@@ -191,6 +191,11 @@ size_t methodset::size() const
   return this->libout::get_impl<impl>()->size();
 }
 
+void methodset::append( library_entry const& entry )
+{
+  this->libout::append(entry);
+}
+
 void methodset::append( method const& m )
 {
   this->libout::get_impl<impl>()->append( m );

--- a/ringing/methodset.h
+++ b/ringing/methodset.h
@@ -70,7 +70,7 @@ public:
   size_t size() const;
 
   // Currently libout doesn't have an append that takes a single method
-  using libout::append;
+  void append( library_entry const& entry );
   void append( method const& );
 
   template <class InputIterator>


### PR DESCRIPTION
Fixes #7 

I thought I could get it to compile by disambiguating the two methods to accept different types of iterators. Turns out I was wrong - the `methodset::append` method is actually accepting both type of iterators!

The actual cause of the ambiguity is that the `using libout::append;` statement pulled both the single member append method (which we want) and the iterator range append method (which we do not want).

Since C++ does not allow `using` to only pull a specific overload, I made a lazy fix here: avoid pulling altogether and simply duplicate the single member `append` method.

IMO, the logic here is a bit convoluted and better to be refactored for long term maintenance. But that is out of the scope of this PR.